### PR TITLE
3.0.x

### DIFF
--- a/classes/kohana/cache/memcache.php
+++ b/classes/kohana/cache/memcache.php
@@ -135,7 +135,7 @@ class Kohana_Cache_Memcache extends Cache {
 			'timeout'          => 1,
 			'retry_interval'   => 15,
 			'status'           => TRUE,
-			'failure_callback' => array($this, '_failed_request'),
+			'failure_callback' => array($this, 'failed_request'),
 		);
 
 		// Add the memcache servers to the pool
@@ -276,7 +276,7 @@ class Kohana_Cache_Memcache extends Cache {
 	 * @return  void|boolean
 	 * @since   3.0.8
 	 */
-	protected function _failed_request($hostname, $port)
+	public function failed_request($hostname, $port)
 	{
 		if ( ! $this->_config['instant_death'])
 			return; 
@@ -304,7 +304,7 @@ class Kohana_Cache_Memcache extends Cache {
 				$host['timeout'],
 				$host['retry_interval'],
 				FALSE,
-				array($this, '_failed_request'
+				array($this, 'failed_request'
 				));
 		}
 	}

--- a/classes/kohana/session/cache.php
+++ b/classes/kohana/session/cache.php
@@ -1,0 +1,81 @@
+<?php defined('SYSPATH') or die('No direct script access.');
+
+class Kohana_Session_Cache extends Session {
+
+	// _memcached instance
+	protected $_memcached;
+
+	// The current session id
+	protected $_session_id;
+
+	// The old session id
+	protected $_update_id;
+
+	public function __construct(array $config = null, $id = NULL)
+	{
+		if ( ! isset($config['group']))
+		{
+			$config['group'] = 'memcache';
+		}
+
+		$this->_db = Cache::instance($config['group']);
+
+		parent::__construct($config, $id);
+	}
+
+	public function id()
+	{
+		return $this->_session_id;
+	}
+
+	protected function _read($id = NULL)
+	{	
+		if (! is_null($id) OR $id = Cookie::get($this->_name))
+		{
+			$ret = $this->_db->get($id);
+			if(false !== $ret)
+			{
+				$this->_session_id = $this->_update_id = $id;
+				return $ret;
+			}
+		}
+
+		$this->_regenerate();
+
+		return NULL;
+	}
+
+	protected function _regenerate()
+	{
+		do
+		{
+			$id = str_replace('.', '', uniqid(NULL, TRUE));
+
+			$ret = $this->_db->get($id);	
+		}
+		while (! is_null($ret));
+
+		return $this->_session_id = $id;
+	}
+
+	protected function _write()
+	{
+		$contents = $this->__toString();
+	
+		$this->_db->set($this->_session_id, $contents, $this->_lifetime);
+
+		$this->_update_id = $this->_session_id;
+
+		Cookie::set($this->_name, $this->_session_id, $this->_lifetime);
+
+		return TRUE;
+	}
+
+	protected function _destroy()
+	{
+		$ret = $this->_db->delete($this->_update_id);
+
+		return $ret;
+	}
+
+} // End Session_Memcached

--- a/classes/session/cache.php
+++ b/classes/session/cache.php
@@ -1,0 +1,3 @@
+<?php defined('SYSPATH') or die('No direct script access.');
+
+class Session_Cache extends Kohana_Session_Cache {}

--- a/config/session.php
+++ b/config/session.php
@@ -1,0 +1,9 @@
+<?php defined('SYSPATH') or die('No direct script access.');
+return array
+(
+	'default' => array
+	(
+		'driver'             => 'cache',
+		'default_expire'     => 3600,
+	)
+);


### PR DESCRIPTION
I added a session handler that will use the cache instead of cookies or native.

This is useful if one would like to keep session data in memory (using memcache for instance) and cannot edit the php.ini file.

http://dev.kohanaframework.org/issues/3337
