### PR TITLE
Fixes #3973, fixed tests errors when removing parent directory with stuff

### DIFF
--- a/classes/kohana/cache/file.php
+++ b/classes/kohana/cache/file.php
@@ -398,7 +398,7 @@ class Kohana_Cache_File extends Cache implements Kohana_Cache_GarbageCollect {
 					unset($files);
 
 					// Try to remove the parent directory
-					return rmdir($file->getRealPath());
+					return self::_rrmdir($file->getRealPath());
 				}
 				catch (ErrorException $e)
 				{
@@ -422,6 +422,32 @@ class Kohana_Cache_File extends Cache implements Kohana_Cache_GarbageCollect {
 			// Throw exception
 			throw $e;
 		}
+	}
+
+	/**
+	 * Recursive remove directory
+	 *
+	 * @param string
+	 * @return void
+	 */
+	protected static function _rrmdir($dir){
+		if (is_dir($dir)) {
+			$objects = scandir($dir);
+			foreach ($objects as $object) {
+				if ($object != "." && $object != "..") {
+					if (filetype($dir."/".$object) == "dir"){
+						rrmdir($dir."/".$object); 
+					}
+					else{
+						unlink($dir."/".$object);
+					}
+				}
+			}
+
+			reset($objects);
+			rmdir($dir);
+		} 
+
 	}
 
 	/**


### PR DESCRIPTION
I replaced the rmdir with a recursive version, basically taken from php.net. I was getting an exception thrown when trying to remove a parent directory with stuff in the parent when I ran the Kohana Cache Test.
