### PR TITLE
3.2/newline bugfix

### DIFF
--- a/classes/kohana/cache/file.php
+++ b/classes/kohana/cache/file.php
@@ -151,8 +151,6 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 					throw new Cache_Exception(__METHOD__.' corrupted cache file!');
 				}
 
-				$cache = $data->fgets();
-
 				// Test the expiry
 				if (($created + (int) $lifetime) < time())
 				{
@@ -162,6 +160,12 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 				}
 				else
 				{
+					$cache = null;
+					while(!$data->eof())
+					{
+						$cache .= $data->fgets();
+					}
+
 					return unserialize($cache);
 				}
 			}


### PR DESCRIPTION
Fixes a bug with cachedata containing newlines parsed incorrectly + a small optimization only reading the cache data if needed
