### PR TITLE
Refs #4101 - If lifetime is less than 2592000, no need add current time

### DIFF
--- a/classes/kohana/cache/memcache.php
+++ b/classes/kohana/cache/memcache.php
@@ -217,13 +217,8 @@ class Kohana_Cache_Memcache extends Cache {
 			// Set the lifetime to maximum cache time
 			$lifetime = Cache_Memcache::CACHE_CEILING + time();
 		}
-		// Else if the lifetime is greater than zero
-		elseif ($lifetime > 0)
-		{
-			$lifetime += time();
-		}
-		// Else
-		else
+		// Else if the lifetime is less than zero
+		elseif ($lifetime < 0)
 		{
 			// Normalise the lifetime
 			$lifetime = 0;


### PR DESCRIPTION
Refs #4101
If lifetime is less than 2592000, no need add current time
