### PR TITLE
Fixes #4303 Cache_File::get sometimes get into racing condition

### DIFF
--- a/classes/kohana/cache/file.php
+++ b/classes/kohana/cache/file.php
@@ -147,7 +147,7 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 
 				// Test the expiry
 				// If we're at the EOF at this point, corrupted!
-				if ($data->eof() || ($created + (int) $lifetime) < time())
+				if ($data->eof() OR ($created + (int) $lifetime) < time())
 				{
 					// Delete the file
 					$this->_delete_file($file, NULL, TRUE);

--- a/classes/kohana/cache/file.php
+++ b/classes/kohana/cache/file.php
@@ -145,10 +145,13 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 				$data     = $file->openFile();
 				$lifetime = $data->fgets();
 
+				// Test the expiry
 				// If we're at the EOF at this point, corrupted!
-				if ($data->eof())
+				if ($data->eof() || ($created + (int) $lifetime) < time())
 				{
-					throw new Cache_Exception(__METHOD__.' corrupted cache file!');
+					// Delete the file
+					$this->_delete_file($file, NULL, TRUE);
+					return $default;
 				}
 
 				$cache = '';
@@ -158,17 +161,7 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 					$cache .= $data->fgets();
 				}
 
-				// Test the expiry
-				if (($created + (int) $lifetime) < time())
-				{
-					// Delete the file
-					$this->_delete_file($file, NULL, TRUE);
-					return $default;
-				}
-				else
-				{
-					return unserialize($cache);
-				}
+				return unserialize($cache);
 			}
 
 		}


### PR DESCRIPTION
I'm using assets with path caching on my server. Because it goes through localhost, all requests are done almost simultaneously. This can lead to the racing condition where one request is asking for the cache file which the other request is currently saving. This leads to Kohana_Cache_File::get corrupted cache file exception because get() loads empty cache file (just created, not yet filled with data).
