### PR TITLE
mencache use is wrong!

### DIFF
--- a/classes/Kohana/Cache/Memcache.php
+++ b/classes/Kohana/Cache/Memcache.php
@@ -215,19 +215,19 @@ class Kohana_Cache_Memcache extends Cache implements Cache_Arithmetic {
 		if ($lifetime > Cache_Memcache::CACHE_CEILING)
 		{
 			// Set the lifetime to maximum cache time
-			$lifetime = Cache_Memcache::CACHE_CEILING + time();
+			$lifetime = Cache_Memcache::CACHE_CEILING;// + time();
 		}
 		// Else if the lifetime is greater than zero
-		elseif ($lifetime > 0)
-		{
-			$lifetime += time();
-		}
+		//elseif ($lifetime > 0)
+		//{
+		//	$lifetime += time();
+		//}
 		// Else
-		else
-		{
+		//else
+		//{
 			// Normalise the lifetime
-			$lifetime = 0;
-		}
+		//	$lifetime = 0;
+		//}
 
 		// Set the data to memcache
 		return $this->_memcache->set($this->_sanitize_id($id), $data, $this->_flags, $lifetime);


### PR DESCRIPTION
http://php.net/manual/zh/memcache.set.php Expiration time of the item. If it's equal to zero, the item will never expire. You can also use Unix timestamp or a number of seconds starting from current time, but in the latter case the number of seconds may not exceed 2592000 (30 days).
