### PR TITLE
Cleanup code

### DIFF
--- a/classes/Cache.php
+++ b/classes/Cache.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 abstract class Cache extends Kohana_Cache {}

--- a/classes/Cache/Apc.php
+++ b/classes/Cache/Apc.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Cache_Apc extends Kohana_Cache_Apc {}

--- a/classes/Cache/Arithmetic.php
+++ b/classes/Cache/Arithmetic.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 interface Cache_Arithmetic extends Kohana_Cache_Arithmetic {}

--- a/classes/Cache/Exception.php
+++ b/classes/Cache/Exception.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Cache_Exception extends Kohana_Cache_Exception {}

--- a/classes/Cache/File.php
+++ b/classes/Cache/File.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Cache_File extends Kohana_Cache_File {}

--- a/classes/Cache/GarbageCollect.php
+++ b/classes/Cache/GarbageCollect.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 interface Cache_GarbageCollect extends Kohana_Cache_GarbageCollect {}

--- a/classes/Cache/Memcache.php
+++ b/classes/Cache/Memcache.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Cache_Memcache extends Kohana_Cache_Memcache {}

--- a/classes/Cache/MemcacheTag.php
+++ b/classes/Cache/MemcacheTag.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Cache_MemcacheTag extends Kohana_Cache_MemcacheTag {}

--- a/classes/Cache/Sqlite.php
+++ b/classes/Cache/Sqlite.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Cache_Sqlite extends Kohana_Cache_Sqlite {}

--- a/classes/Cache/Tagging.php
+++ b/classes/Cache/Tagging.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 interface Cache_Tagging extends Kohana_Cache_Tagging {}

--- a/classes/Cache/Wincache.php
+++ b/classes/Cache/Wincache.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Cache_Wincache extends Kohana_Cache_Wincache {}

--- a/classes/HTTP/Cache.php
+++ b/classes/HTTP/Cache.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Cache extends Kohana_HTTP_Cache {}

--- a/classes/Kohana/Cache.php
+++ b/classes/Kohana/Cache.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Kohana Cache provides a common interface to a variety of caching engines. Tags are
  * supported where available natively to the cache system. Kohana Cache supports multiple
@@ -297,4 +297,3 @@ abstract class Kohana_Cache {
 		return str_replace(array('/', '\\', ' '), '_', $id);
 	}
 }
-// End Kohana_Cache

--- a/classes/Kohana/Cache/Apc.php
+++ b/classes/Kohana/Cache/Apc.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * [Kohana Cache](api/Kohana_Cache) APC driver. Provides an opcode based
  * driver for the Kohana Cache library.
@@ -64,7 +64,7 @@ class Kohana_Cache_Apc extends Cache implements Cache_Arithmetic {
 	 *     // Retrieve cache entry from apc group and return 'bar' if miss
 	 *     $data = Cache::instance('apc')->get('foo', 'bar');
 	 *
-	 * @param   string  $id       id of cache to entry
+	 * @param   string  $id       ID of cache entry
 	 * @param   string  $default  default value to return if cache miss
 	 * @return  mixed
 	 * @throws  Cache_Exception
@@ -163,4 +163,4 @@ class Kohana_Cache_Apc extends Cache implements Cache_Arithmetic {
 		return apc_dec($id, $step);
 	}
 
-} // End Kohana_Cache_Apc
+}

--- a/classes/Kohana/Cache/Arithmetic.php
+++ b/classes/Kohana/Cache/Arithmetic.php
@@ -1,8 +1,8 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Kohana Cache Arithmetic Interface, for basic cache integer based
  * arithmetic, addition and subtraction
- * 
+ *
  * @package    Kohana/Cache
  * @category   Base
  * @author     Kohana Team
@@ -36,4 +36,4 @@ interface Kohana_Cache_Arithmetic {
 	 */
 	public function decrement($id, $step = 1);
 
-} // End Kohana_Cache_Arithmetic
+}

--- a/classes/Kohana/Cache/Exception.php
+++ b/classes/Kohana/Cache/Exception.php
@@ -1,7 +1,7 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Kohana Cache Exception
- * 
+ *
  * @package    Kohana/Cache
  * @category   Base
  * @author     Kohana Team

--- a/classes/Kohana/Cache/File.php
+++ b/classes/Kohana/Cache/File.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * [Kohana Cache](api/Kohana_Cache) File driver. Provides a file based
  * driver for the Kohana Cache library. This is one of the slowest

--- a/classes/Kohana/Cache/GarbageCollect.php
+++ b/classes/Kohana/Cache/GarbageCollect.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Garbage Collection interface for caches that have no GC methods
  * of their own, such as [Cache_File] and [Cache_Sqlite]. Memory based

--- a/classes/Kohana/Cache/Memcache.php
+++ b/classes/Kohana/Cache/Memcache.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * [Kohana Cache](api/Kohana_Cache) Memcache driver,
  *

--- a/classes/Kohana/Cache/MemcacheTag.php
+++ b/classes/Kohana/Cache/MemcacheTag.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * See [Kohana_Cache_Memcache]
  *

--- a/classes/Kohana/Cache/Sqlite.php
+++ b/classes/Kohana/Cache/Sqlite.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Kohana Cache Sqlite Driver
  *
@@ -68,8 +68,8 @@ class Kohana_Cache_Sqlite extends Cache implements Cache_Tagging, Cache_GarbageC
 	/**
 	 * Retrieve a value based on an id
 	 *
-	 * @param   string  $id       id
-	 * @param   string  $default  default [Optional] Default value to return if id not found
+	 * @param   string  $id       ID of cache entry
+	 * @param   string  $default  Default value to return if id not found [Optional]
 	 * @return  mixed
 	 * @throws  Cache_Exception
 	 */
@@ -120,9 +120,9 @@ class Kohana_Cache_Sqlite extends Cache implements Cache_Tagging, Cache_GarbageC
 	/**
 	 * Set a value based on an id. Optionally add tags.
 	 *
-	 * @param   string   $id        id
-	 * @param   mixed    $data      data
-	 * @param   integer  $lifetime  lifetime [Optional]
+	 * @param   string   $id        ID of cache entry
+	 * @param   mixed    $data      The data to cache
+	 * @param   integer  $lifetime  Lifetime in seconds [Optional]
 	 * @return  boolean
 	 */
 	public function set($id, $data, $lifetime = NULL)
@@ -133,7 +133,7 @@ class Kohana_Cache_Sqlite extends Cache implements Cache_Tagging, Cache_GarbageC
 	/**
 	 * Delete a cache entry based on id
 	 *
-	 * @param   string  $id  id
+	 * @param   string  $id  ID of cache entry
 	 * @return  boolean
 	 * @throws  Cache_Exception
 	 */
@@ -181,10 +181,10 @@ class Kohana_Cache_Sqlite extends Cache implements Cache_Tagging, Cache_GarbageC
 	/**
 	 * Set a value based on an id. Optionally add tags.
 	 *
-	 * @param   string   $id        id
-	 * @param   mixed    $data      data
-	 * @param   integer  $lifetime  lifetime [Optional]
-	 * @param   array    $tags      tags [Optional]
+	 * @param   string   $id        ID of cache entry
+	 * @param   mixed    $data      Data to set to cache
+	 * @param   integer  $lifetime  Lifetime in seconds [Optional]
+	 * @param   array    $tags      Tags [Optional]
 	 * @return  boolean
 	 * @throws  Cache_Exception
 	 */
@@ -226,7 +226,7 @@ class Kohana_Cache_Sqlite extends Cache implements Cache_Tagging, Cache_GarbageC
 	/**
 	 * Delete cache entries based on a tag
 	 *
-	 * @param   string  $tag  tag
+	 * @param   string  $tag  Tag of cache entry
 	 * @return  boolean
 	 * @throws  Cache_Exception
 	 */
@@ -251,7 +251,7 @@ class Kohana_Cache_Sqlite extends Cache implements Cache_Tagging, Cache_GarbageC
 	/**
 	 * Find cache entries based on a tag
 	 *
-	 * @param   string  $tag  tag
+	 * @param   string  $tag  Tag of cache entry
 	 * @return  array
 	 * @throws  Cache_Exception
 	 */
@@ -313,7 +313,7 @@ class Kohana_Cache_Sqlite extends Cache implements Cache_Tagging, Cache_GarbageC
 	/**
 	 * Tests whether an id exists or not
 	 *
-	 * @param   string  $id  id
+	 * @param   string  $id  ID of cache entry
 	 * @return  boolean
 	 * @throws  Cache_Exception
 	 */

--- a/classes/Kohana/Cache/Tagging.php
+++ b/classes/Kohana/Cache/Tagging.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Kohana Cache Tagging Interface
  *

--- a/classes/Kohana/Cache/Wincache.php
+++ b/classes/Kohana/Cache/Wincache.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * [Kohana Cache](api/Kohana_Cache) Wincache driver. Provides an opcode based
  * driver for the Kohana Cache library.

--- a/classes/Kohana/HTTP/Cache.php
+++ b/classes/Kohana/HTTP/Cache.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * HTTT Caching adaptor class that provides caching services to the
  * [Request_Client] class, using HTTP cache control logic as defined in
@@ -22,13 +22,13 @@ class Kohana_HTTP_Cache {
 	/**
 	 * Factory method for HTTP_Cache that provides a convenient dependency
 	 * injector for the Cache library.
-	 * 
+	 *
 	 *      // Create HTTP_Cache with named cache engine
 	 *      $http_cache = HTTP_Cache::factory('memcache', array(
 	 *          'allow_private_cache' => FALSE
 	 *          )
 	 *      );
-	 * 
+	 *
 	 *      // Create HTTP_Cache with supplied cache engine
 	 *      $http_cache = HTTP_Cache::factory(Cache::instance('memcache'),
 	 *          array(
@@ -57,7 +57,7 @@ class Kohana_HTTP_Cache {
 	 * Basic cache key generator that hashes the entire request and returns
 	 * it. This is fine for static content, or dynamic content where user
 	 * specific information is encoded into the request.
-	 * 
+	 *
 	 *      // Generate cache key
 	 *      $cache_key = HTTP_Cache::basic_cache_key_generator($request);
 	 *
@@ -104,7 +104,7 @@ class Kohana_HTTP_Cache {
 	 * Constructor method for this class. Allows dependency injection of the
 	 * required components such as `Cache` and the cache key generator.
 	 *
-	 * @param   array $options 
+	 * @param   array $options
 	 */
 	public function __construct(array $options = array())
 	{
@@ -140,8 +140,8 @@ class Kohana_HTTP_Cache {
 
 		// If this is a destructive request, by-pass cache completely
 		if (in_array($request->method(), array(
-			HTTP_Request::POST, 
-			HTTP_Request::PUT, 
+			HTTP_Request::POST,
+			HTTP_Request::PUT,
 			HTTP_Request::DELETE)))
 		{
 			// Kill existing caches for this request
@@ -177,7 +177,7 @@ class Kohana_HTTP_Cache {
 		// Cache the response
 		$this->cache_response($cache_key, $request, $response);
 
-		$response->headers(HTTP_Cache::CACHE_STATUS_KEY, 
+		$response->headers(HTTP_Cache::CACHE_STATUS_KEY,
 			HTTP_Cache::CACHE_STATUS_MISS);
 
 		return $response;
@@ -241,19 +241,19 @@ class Kohana_HTTP_Cache {
 	 * Sets or gets the cache key generator callback for this caching
 	 * class. The cache key generator provides a unique hash based on the
 	 * `Request` object passed to it.
-	 * 
+	 *
 	 * The default generator is [HTTP_Cache::basic_cache_key_generator()], which
 	 * serializes the entire `HTTP_Request` into a unique sha1 hash. This will
 	 * provide basic caching for static and simple dynamic pages. More complex
 	 * algorithms can be defined and then passed into `HTTP_Cache` using this
 	 * method.
-	 * 
+	 *
 	 *      // Get the cache key callback
 	 *      $callback = $http_cache->cache_key_callback();
-	 * 
+	 *
 	 *      // Set the cache key callback
 	 *      $http_cache->cache_key_callback('Foo::cache_key');
-	 * 
+	 *
 	 *      // Alternatively, in PHP 5.3 use a closure
 	 *      $http_cache->cache_key_callback(function (Request $request) {
 	 *            return sha1($request->render());
@@ -278,7 +278,7 @@ class Kohana_HTTP_Cache {
 	/**
 	 * Creates a cache key for the request to use for caching
 	 * [Kohana_Response] returned by [Request::execute].
-	 * 
+	 *
 	 * This is the default cache key generating logic, but can be overridden
 	 * by setting [HTTP_Cache::cache_key_callback()].
 	 *
@@ -500,4 +500,4 @@ class Kohana_HTTP_Cache {
 		return $this->_response_time - $this->_request_time;
 	}
 
-} // End Kohana_HTTP_Cache
+}

--- a/config/cache.php
+++ b/config/cache.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 return array
 (
 /*	'memcache' => array(

--- a/config/userguide.php
+++ b/config/userguide.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 return array(
 	// Leave this alone
@@ -9,15 +9,15 @@ return array(
 
 			// Whether this modules userguide pages should be shown
 			'enabled' => TRUE,
-			
+
 			// The name that should show up on the userguide index page
 			'name' => 'Cache',
 
 			// A short description of this module, shown on the index page
 			'description' => 'Common interface for caching engines.',
-			
+
 			// Copyright message, shown in the footer for this module
 			'copyright' => '&copy; 2008–2012 Kohana Team',
-		)	
+		)
 	)
 );

--- a/tests/cache/CacheBasicMethodsTest.php
+++ b/tests/cache/CacheBasicMethodsTest.php
@@ -19,9 +19,9 @@ abstract class Kohana_CacheBasicMethodsTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * This method MUST be implemented by each driver to setup the `Cache`
 	 * instance for each test.
-	 * 
+	 *
 	 * This method should do the following tasks for each driver test:
-	 * 
+	 *
 	 *  - Test the Cache instance driver is available, skip test otherwise
 	 *  - Setup the Cache instance
 	 *  - Call the parent setup method, `parent::setUp()`
@@ -34,7 +34,7 @@ abstract class Kohana_CacheBasicMethodsTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Accessor method to `$_cache_driver`. 
+	 * Accessor method to `$_cache_driver`.
 	 *
 	 * @return  Cache
 	 * @return  self
@@ -60,9 +60,9 @@ abstract class Kohana_CacheBasicMethodsTest extends PHPUnit_Framework_TestCase {
 		$object->bar = 'bar';
 
 		$html_text = <<<TESTTEXT
-<!doctype html>  
-<head> 
-</head> 
+<!doctype html>
+<head>
+</head>
 
 <body>
 </body>
@@ -202,16 +202,16 @@ TESTTEXT;
 
 	/**
 	 * Tests the [Cache::set()] method, testing;
-	 * 
+	 *
 	 *  - The value is cached
 	 *  - The lifetime is respected
 	 *  - The returned value type is as expected
 	 *  - The default not-found value is respected
-	 * 
+	 *
 	 * @dataProvider provider_set_get
 	 *
-	 * @param   array    data 
-	 * @param   mixed    expected 
+	 * @param   array    data
+	 * @param   mixed    expected
 	 * @return  void
 	 */
 	public function test_set_get(array $data, $expected)
@@ -236,7 +236,7 @@ TESTTEXT;
 
 	/**
 	 * Tests the [Cache::delete()] method, testing;
-	 * 
+	 *
 	 *  - The a cached value is deleted from cache
 	 *  - The cache returns a TRUE value upon deletion
 	 *  - The cache returns a FALSE value if no value exists to delete
@@ -291,9 +291,9 @@ TESTTEXT;
 		foreach ($data as $key => $values)
 		{
 			// Verify data has been purged
-			$this->assertSame('Cache Deleted!', $cache->get($values[0]['id'], 
+			$this->assertSame('Cache Deleted!', $cache->get($values[0]['id'],
 				'Cache Deleted!'));
 		}
 	}
 
-} // End Kohana_CacheBasicMethodsTest
+}

--- a/tests/cache/CacheTest.php
+++ b/tests/cache/CacheTest.php
@@ -53,7 +53,7 @@ class Kohana_CacheTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests the [Cache::factory()] method behaves as expected
-	 * 
+	 *
 	 * @dataProvider provider_instance
 	 *
 	 * @return  void
@@ -101,7 +101,7 @@ class Kohana_CacheTest extends PHPUnit_Framework_TestCase {
 		}
 		catch (Cache_Exception $e)
 		{
-			$this->assertSame('Cloning of Kohana_Cache objects is forbidden', 
+			$this->assertSame('Cloning of Kohana_Cache objects is forbidden',
 				$e->getMessage());
 			throw $e;
 		}
@@ -154,7 +154,7 @@ class Kohana_CacheTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests the config method behaviour
-	 * 
+	 *
 	 * @dataProvider provider_config
 	 *
 	 * @param   mixed    key value to set or get
@@ -215,11 +215,11 @@ class Kohana_CacheTest extends PHPUnit_Framework_TestCase {
 	 * Tests the [Cache::_sanitize_id()] method works as expected.
 	 * This uses some nasty reflection techniques to access a protected
 	 * method.
-	 * 
+	 *
 	 * @dataProvider provider_sanitize_id
 	 *
-	 * @param   string    id 
-	 * @param   string    expected 
+	 * @param   string    id
+	 * @param   string    expected
 	 * @return  void
 	 */
 	public function test_sanitize_id($id, $expected)
@@ -239,4 +239,4 @@ class Kohana_CacheTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertSame($expected, $sanitize_id->invoke($cache, $id));
 	}
-} // End Kohana_CacheTest
+}

--- a/tests/cache/FileTest.php
+++ b/tests/cache/FileTest.php
@@ -15,9 +15,9 @@ class Kohana_Cache_FileTest extends Kohana_CacheBasicMethodsTest {
 	/**
 	 * This method MUST be implemented by each driver to setup the `Cache`
 	 * instance for each test.
-	 * 
+	 *
 	 * This method should do the following tasks for each driver test:
-	 * 
+	 *
 	 *  - Test the Cache instance driver is available, skip test otherwise
 	 *  - Setup the Cache instance
 	 *  - Call the parent setup method, `parent::setUp()`
@@ -95,4 +95,4 @@ class Kohana_Cache_FileTest extends Kohana_CacheBasicMethodsTest {
 		$this->assertSame($expected, $cache->get('utf8'));
 	}
 
-} // End Kohana_SqliteTest
+}

--- a/tests/cache/SqliteTest.php
+++ b/tests/cache/SqliteTest.php
@@ -15,9 +15,9 @@ class Kohana_SqliteTest extends Kohana_CacheBasicMethodsTest {
 	/**
 	 * This method MUST be implemented by each driver to setup the `Cache`
 	 * instance for each test.
-	 * 
+	 *
 	 * This method should do the following tasks for each driver test:
-	 * 
+	 *
 	 *  - Test the Cache instance driver is available, skip test otherwise
 	 *  - Setup the Cache instance
 	 *  - Call the parent setup method, `parent::setUp()`
@@ -41,4 +41,4 @@ class Kohana_SqliteTest extends Kohana_CacheBasicMethodsTest {
 		$this->cache(Cache::instance('sqlite'));
 	}
 
-} // End Kohana_SqliteTest
+}

--- a/tests/cache/WincacheTest.php
+++ b/tests/cache/WincacheTest.php
@@ -15,9 +15,9 @@ class Kohana_WincacheTest extends Kohana_CacheBasicMethodsTest {
 	/**
 	 * This method MUST be implemented by each driver to setup the `Cache`
 	 * instance for each test.
-	 * 
+	 *
 	 * This method should do the following tasks for each driver test:
-	 * 
+	 *
 	 *  - Test the Cache instance driver is available, skip test otherwise
 	 *  - Setup the Cache instance
 	 *  - Call the parent setup method, `parent::setUp()`
@@ -36,4 +36,4 @@ class Kohana_WincacheTest extends Kohana_CacheBasicMethodsTest {
 		$this->cache(Cache::instance('wincache'));
 	}
 
-} // End Kohana_WincacheTest
+}

--- a/tests/cache/arithmetic/ApcTest.php
+++ b/tests/cache/arithmetic/ApcTest.php
@@ -15,9 +15,9 @@ class Kohana_ApcTest extends Kohana_CacheArithmeticMethodsTest {
 	/**
 	 * This method MUST be implemented by each driver to setup the `Cache`
 	 * instance for each test.
-	 * 
+	 *
 	 * This method should do the following tasks for each driver test:
-	 * 
+	 *
 	 *  - Test the Cache instance driver is available, skip test otherwise
 	 *  - Setup the Cache instance
 	 *  - Call the parent setup method, `parent::setUp()`
@@ -44,21 +44,21 @@ class Kohana_ApcTest extends Kohana_CacheArithmeticMethodsTest {
 
 	/**
 	 * Tests the [Cache::set()] method, testing;
-	 * 
+	 *
 	 *  - The value is cached
 	 *  - The lifetime is respected
 	 *  - The returned value type is as expected
 	 *  - The default not-found value is respected
-	 * 
+	 *
 	 * This test doesn't test the TTL as there is a known bug/feature
 	 * in APC that prevents the same request from killing cache on timeout.
-	 * 
+	 *
 	 * @link   http://pecl.php.net/bugs/bug.php?id=16814
-	 * 
+	 *
 	 * @dataProvider provider_set_get
 	 *
-	 * @param   array    data 
-	 * @param   mixed    expected 
+	 * @param   array    data
+	 * @param   mixed    expected
 	 * @return  void
 	 */
 	public function test_set_get(array $data, $expected)
@@ -72,4 +72,4 @@ class Kohana_ApcTest extends Kohana_CacheArithmeticMethodsTest {
 		parent::test_set_get($data, $expected);
 	}
 
-} // End Kohana_ApcTest
+}

--- a/tests/cache/arithmetic/CacheArithmeticMethods.php
+++ b/tests/cache/arithmetic/CacheArithmeticMethods.php
@@ -70,7 +70,7 @@ abstract class Kohana_CacheArithmeticMethodsTest extends Kohana_CacheBasicMethod
 
 	/**
 	 * Test for [Cache_Arithmetic::increment()]
-	 * 
+	 *
 	 * @dataProvider provider_increment
 	 *
 	 * @param   integer  start state
@@ -142,7 +142,7 @@ abstract class Kohana_CacheArithmeticMethodsTest extends Kohana_CacheBasicMethod
 
 	/**
 	 * Test for [Cache_Arithmetic::decrement()]
-	 * 
+	 *
 	 * @dataProvider provider_decrement
 	 *
 	 * @param   integer  start state
@@ -170,4 +170,4 @@ abstract class Kohana_CacheArithmeticMethodsTest extends Kohana_CacheBasicMethod
 		);
 	}
 
-} // End Kohana_CacheArithmeticMethodsTest
+}

--- a/tests/cache/arithmetic/MemcacheTest.php
+++ b/tests/cache/arithmetic/MemcacheTest.php
@@ -16,9 +16,9 @@ class Kohana_CacheArithmeticMemcacheTest extends Kohana_CacheArithmeticMethodsTe
 	/**
 	 * This method MUST be implemented by each driver to setup the `Cache`
 	 * instance for each test.
-	 * 
+	 *
 	 * This method should do the following tasks for each driver test:
-	 * 
+	 *
 	 *  - Test the Cache instance driver is available, skip test otherwise
 	 *  - Setup the Cache instance
 	 *  - Call the parent setup method, `parent::setUp()`
@@ -39,7 +39,7 @@ class Kohana_CacheArithmeticMemcacheTest extends Kohana_CacheArithmeticMethodsTe
 		}
 
 		$memcache = new Memcache;
-		if ( ! $memcache->connect($config['servers']['local']['host'], 
+		if ( ! $memcache->connect($config['servers']['local']['host'],
 			$config['servers']['local']['port']))
 		{
 			$this->markTestSkipped('Unable to connect to memcache server @ '.
@@ -64,7 +64,7 @@ class Kohana_CacheArithmeticMemcacheTest extends Kohana_CacheArithmeticMethodsTe
 	 * Tests that multiple values set with Memcache do not cause unexpected
 	 * results. For accurate results, this should be run with a memcache
 	 * configuration that includes multiple servers.
-	 * 
+	 *
 	 * This is to test #4110
 	 *
 	 * @link    http://dev.kohanaframework.org/issues/4110
@@ -100,4 +100,4 @@ class Kohana_CacheArithmeticMemcacheTest extends Kohana_CacheArithmeticMethodsTe
 	}
 
 
-} // End Kohana_CacheArithmeticMemcacheTest
+}

--- a/tests/cache/request/client/CacheTest.php
+++ b/tests/cache/request/client/CacheTest.php
@@ -80,7 +80,7 @@ class Kohana_Request_Client_CacheTest extends Unittest_TestCase {
 
 		$response = $request->client()->execute($request);
 
-		$this->assertSame(HTTP_Cache::CACHE_STATUS_MISS, 
+		$this->assertSame(HTTP_Cache::CACHE_STATUS_MISS,
 			$response->headers(HTTP_Cache::CACHE_STATUS_KEY));
 	}
 
@@ -119,7 +119,7 @@ class Kohana_Request_Client_CacheTest extends Unittest_TestCase {
 				->cache_response($key, $request, $response)
 		);
 
-		$this->assertSame(HTTP_Cache::CACHE_STATUS_SAVED, 
+		$this->assertSame(HTTP_Cache::CACHE_STATUS_SAVED,
 			$response->headers(HTTP_Cache::CACHE_STATUS_KEY));
 	}
 
@@ -143,7 +143,7 @@ class Kohana_Request_Client_CacheTest extends Unittest_TestCase {
 
 		$response->headers(array(
 			'cache-control'                  => 'max-age='.$lifetime,
-			HTTP_Cache::CACHE_STATUS_KEY => 
+			HTTP_Cache::CACHE_STATUS_KEY =>
 				HTTP_Cache::CACHE_STATUS_HIT
 		));
 
@@ -254,12 +254,12 @@ class Kohana_Request_Client_CacheTest extends Unittest_TestCase {
 	{
 		return $this->getMock('Cache_File', array(), array(), '', FALSE);
 	}
-} // End Kohana_Request_Client_CacheTest
+}
 
-class Controller_Kohana_Request_CacheTest_Dummy extends Controller 
+class Controller_Kohana_Request_CacheTest_Dummy extends Controller
 {
 	public function action_index()
 	{
-	
+
 	}
 }


### PR DESCRIPTION
- Corrected a bit `classes/Kohana/Cache/Sqlite.php`, to show what needs to change in the other classes
- Replaced all 

``` php
<?php defined('SYSPATH') or die('No direct script access.');
```

by

``` php
<?php defined('SYSPATH') OR die('No direct script access.');
```
- Amended PHPDoc (`classes/Kohana/Cache/Sqlite.php`)
- Removed unnecessary comment at the end of classes, e.g.: `// End Kohana_Classname`
- Removed trailing spaces

Please see: http://dev.kohanaframework.org/issues/4768
