### PR TITLE
Calling mkdir with a NULL $context does not make directory

### DIFF
--- a/classes/Kohana/Cache/File.php
+++ b/classes/Kohana/Cache/File.php
@@ -219,14 +219,7 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 		// If the directory path is not a directory
 		if ( ! $dir->isDir())
 		{
-			// Create the directory
-			if ( ! mkdir($directory, 0777, TRUE))
-			{
-				throw new Cache_Exception(__METHOD__.' unable to create directory : :directory', array(':directory' => $directory));
-			}
-
-			// chmod to solve potential umask issues
-			chmod($directory, 0777);
+			$this->_make_directory($directory, 0777, TRUE);
 		}
 
 		// Open file to inspect
@@ -446,21 +439,30 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 	 * `mkdir` to ensure DRY principles
 	 *
 	 * @link    http://php.net/manual/en/function.mkdir.php
-	 * @param   string    $directory
-	 * @param   integer   $mode
-	 * @param   boolean   $recursive
-	 * @param   resource  $context
+	 * @param   string    $directory    directory path
+	 * @param   integer   $mode         chmod mode
+	 * @param   boolean   $recursive    allows nested directories creation
+	 * @param   resource  $context      a stream context
 	 * @return  SplFileInfo
 	 * @throws  Cache_Exception
 	 */
 	protected function _make_directory($directory, $mode = 0777, $recursive = FALSE, $context = NULL)
 	{
-		if ( ! mkdir($directory, $mode, $recursive, $context))
+		// call mkdir according to the availability of a passed $context param
+		$mkdir_result = $context ?
+			mkdir($directory, $mode, $recursive, $context) :
+			mkdir($directory, $mode, $recursive);
+
+		// throw an exception if unsuccessful
+		if ( ! $mkdir_result)
 		{
 			throw new Cache_Exception('Failed to create the defined cache directory : :directory', array(':directory' => $directory));
 		}
+
+		// chmod to solve potential umask issues
 		chmod($directory, $mode);
 
 		return new SplFileInfo($directory);
 	}
+
 }


### PR DESCRIPTION
In the `_make_directory` wrapper, call `mkdir` with
respect to the availability of a passed $context
parameter.

Also removed a `mkdir` call in the `set` method
to use the `_make_directory` method instead.

Related to #59 and also to #53 and #54 
