### PR TITLE
Fix Cache_File TTL=0 to mean "never expires"

### DIFF
--- a/classes/Kohana/Cache/File.php
+++ b/classes/Kohana/Cache/File.php
@@ -143,7 +143,7 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 				// Open the file and parse data
 				$created  = $file->getMTime();
 				$data     = $file->openFile();
-				$lifetime = $data->fgets();
+				$lifetime = (int) $data->fgets();
 
 				// If we're at the EOF at this point, corrupted!
 				if ($data->eof())
@@ -159,7 +159,7 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 				}
 
 				// Test the expiry
-				if (($created + (int) $lifetime) < time())
+				if (($lifetime !== 0) AND (($created + $lifetime) < time()))
 				{
 					// Delete the file
 					$this->_delete_file($file, NULL, TRUE);

--- a/tests/cache/CacheBasicMethodsTest.php
+++ b/tests/cache/CacheBasicMethodsTest.php
@@ -166,6 +166,17 @@ TESTTEXT;
 			),
 			array(
 				array(
+					'id'      => 'test ttl 0 means never expire',
+					'value'   => 'cache value that should last',
+					'ttl'     => 0,
+					'wait'    => 1,
+					'type'    => 'string',
+					'default' => NULL
+				),
+				'cache value that should last'
+			),
+			array(
+				array(
 					'id'      => 'bar',
 					'value'   => 'foo',
 					'ttl'     => 3,


### PR DESCRIPTION
The cache expiration test is now negative when
`$lifetime` (TTL) is 0.

Closes #50
