### PR TITLE
Cache_File driver: Fix expiry test and garbage collection

### DIFF
--- a/classes/Kohana/Cache/File.php
+++ b/classes/Kohana/Cache/File.php
@@ -140,24 +140,20 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 			}
 			else
 			{
-				// Open the file and parse data
-				$created  = $file->getMTime();
-				$data     = $file->openFile();
-				$lifetime = (int) $data->fgets();
-
-				// If we're at the EOF at this point, corrupted!
-				if ($data->eof())
-				{
-					throw new Cache_Exception(__METHOD__.' corrupted cache file!');
-				}
-
 				// Test the expiry
-				if (($lifetime !== 0) AND (($created + $lifetime) < time()))
+				if ($this->_is_expired($file))
 				{
 					// Delete the file
 					$this->_delete_file($file, FALSE, TRUE);
 					return $default;
 				}
+
+				// open the file to read data
+				$data = $file->openFile();
+
+				// Run first fgets(). Cache data starts from the second line
+				// as the first contains the lifetime timestamp
+				$data->fgets();
 
 				$cache = '';
 
@@ -328,9 +324,7 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 					else
 					{
 						// Assess the file expiry to flag it for deletion
-						$json = $file->openFile('r')->current();
-						$data = json_decode($json);
-						$delete = $data->expiry < time();
+						$delete = $this->_is_expired($file);
 					}
 
 					// If the delete flag is set delete file
@@ -463,4 +457,29 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 		return new SplFileInfo($directory);
 	}
 
+	/**
+	 * Test if cache file is expired
+	 *
+	 * @param SplFileInfo $file the cache file
+	 * @return boolean TRUE if expired false otherwise
+	 */
+	protected function _is_expired(SplFileInfo $file)
+	{
+		// Open the file and parse data
+		$created = $file->getMTime();
+		$data = $file->openFile("r");
+		$lifetime = (int) $data->fgets();
+
+		// If we're at the EOF at this point, corrupted!
+		if ($data->eof())
+		{
+			throw new Cache_Exception(__METHOD__ . ' corrupted cache file!');
+		}
+
+		//close file
+		$data = null;
+
+		// test for expiry and return
+		return (($lifetime !== 0) AND ( ($created + $lifetime) < time()));
+	}
 }

--- a/classes/Kohana/Cache/File.php
+++ b/classes/Kohana/Cache/File.php
@@ -155,7 +155,7 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 				if (($lifetime !== 0) AND (($created + $lifetime) < time()))
 				{
 					// Delete the file
-					$this->_delete_file($file, NULL, TRUE);
+					$this->_delete_file($file, FALSE, TRUE);
 					return $default;
 				}
 
@@ -258,7 +258,7 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 		$filename = Cache_File::filename($this->_sanitize_id($id));
 		$directory = $this->_resolve_directory($filename);
 
-		return $this->_delete_file(new SplFileInfo($directory.$filename), NULL, TRUE);
+		return $this->_delete_file(new SplFileInfo($directory.$filename), FALSE, TRUE);
 	}
 
 	/**
@@ -366,7 +366,7 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 						// Create new file resource
 						$fp = new SplFileInfo($files->getRealPath());
 						// Delete the file
-						$this->_delete_file($fp);
+						$this->_delete_file($fp, $retain_parent_directory, $ignore_errors, $only_expired);
 					}
 
 					// Move the file pointer on


### PR DESCRIPTION
Recursive calls of Cache_File::_delete_file should keep `$retain_parent_directory`, `$ignore_errors`, `$only_expired` variable values. Fixes garbage collection.

Cache_File::_delete_file was using a wrong JSON-based cache expiry test implementation.

DRY things out and separate logic that tests for the expiry in a protected method.

This slightly slow things out, as a single Cache::get will open and read the cache file twice.

Thanks @MaciejKrol
Ref #70
