### PR TITLE
Test ignore_on_delete config setting on an arbitrary file

### DIFF
--- a/tests/cache/FileTest.php
+++ b/tests/cache/FileTest.php
@@ -38,6 +38,7 @@ class Kohana_Cache_FileTest extends Kohana_CacheBasicMethodsTest {
 						'cache_dir'          => APPPATH.'cache',
 						'default_expire'     => 3600,
 						'ignore_on_delete'   => array(
+							'file_we_want_to_keep.cache',
 							'.gitignore',
 							'.git',
 							'.svn'
@@ -58,7 +59,7 @@ class Kohana_Cache_FileTest extends Kohana_CacheBasicMethodsTest {
 	{
 		$cache = $this->cache();
 		$config = Kohana::$config->load('cache')->file;
-		$file = $config['cache_dir'].'/.gitignore';
+		$file = $config['cache_dir'].'/file_we_want_to_keep.cache';
 
 		// Lets pollute the cache folder
 		file_put_contents($file, 'foobar');


### PR DESCRIPTION
When unit-testing a Kohana application the conventional way, without
Koharness and with the cache tests enabled, the .gitignore file in the
`application/cache` folder ends up deleted.

With this change, tests does not affect `.gitignore` but run on an
arbitrary `file_we_want_to_keep.cache` file that gets created while
testing, and then destroyed.
