### PR TITLE
Travis CI: Install APCu from PECL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,11 @@ services:
   - memcached
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != "hhvm" ]] ; then phpenv config-add cachedrivers.php.ini ; fi
+  - if [[ $TRAVIS_PHP_VERSION != "hhvm" ]]; then INI_FILE=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; else INI_FILE=/etc/hhvm/php.ini; fi;
+  - if [[ $TRAVIS_PHP_VERSION = 5.* ]]; then echo extension = memcache.so >> $INI_FILE; fi;
+  - if [[ $TRAVIS_PHP_VERSION = 5.* ]]; then (echo yes | pecl install -f apcu-4.0.10 && echo apc.enable_cli = 1 >> $INI_FILE); fi;
+  - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then (echo yes | pecl install -f apcu-5.1.2 && echo apc.enable_cli = 1 >> $INI_FILE); fi;
+  - if [[ $TRAVIS_PHP_VERSION != "hhvm" ]] ; then echo -e 'apc.max_file_size = 0\napc.cache_by_default = 0' >> $INI_FILE ; fi
   - composer install --prefer-dist
   - if [ "$COMPOSER_PHPUNIT" = "lowest" ]; then composer update --prefer-lowest --with-dependencies phpunit/phpunit; fi;
   - vendor/bin/koharness

--- a/cachedrivers.php.ini
+++ b/cachedrivers.php.ini
@@ -1,8 +1,0 @@
-; This config file provisions the required PHP extensions for cache drivers on travis
-extension = "apc.so"
-extension = "memcache.so"
-apc.enable_cli = 1
-; The APC opcode cache needs to be disabled to avoid https://github.com/composer/composer/issues/264
-; This allows us to use the user cache
-apc.max_file_size = 0
-apc.cache_by_default = 0

--- a/classes/Kohana/Cache/Apcu.php
+++ b/classes/Kohana/Cache/Apcu.php
@@ -145,7 +145,11 @@ class Kohana_Cache_Apcu extends Cache implements Cache_Arithmetic {
 	 */
 	public function increment($id, $step = 1)
 	{
-		return apcu_inc($id, $step);
+		if (apcu_exists($id)) {
+			return apcu_inc($id, $step);
+		} else {
+			return FALSE;
+		}
 	}
 
 	/**
@@ -160,7 +164,11 @@ class Kohana_Cache_Apcu extends Cache implements Cache_Arithmetic {
 	 */
 	public function decrement($id, $step = 1)
 	{
-		return apcu_dec($id, $step);
+		if (apcu_exists($id)) {
+			return apcu_dec($id, $step);
+		} else {
+			return FALSE;
+		}
 	}
 
 } // End Kohana_Cache_Apcu


### PR DESCRIPTION
APC is not being properly installed and enabled for PHP 5.5 and 5.6. It did not catch our attention because the related tests were being skipped. In Kohana v3.4, some tests are running on separate process, which made some warnings, related to APC not being loaded, to be bubbled up to the main process, breaking the build.

This PR is largely inspired from the [.travis.yml of Symfony](https://github.com/symfony/symfony/blob/master/.travis.yml#L38), it:
- Removes `cachedrivers.php.ini` and use existing system INI files.
- Installs Memcache only for PHP 5.*

Related to #79 and to https://github.com/travis-ci/travis-ci/issues/5296#issuecomment-173868617

Thanks!
