### PR TITLE
Stopping $config['instant_death'] from causing E500

### DIFF
--- a/classes/Kohana/Cache/Memcache.php
+++ b/classes/Kohana/Cache/Memcache.php
@@ -120,6 +120,9 @@ class Kohana_Cache_Memcache extends Cache implements Cache_Arithmetic {
 			throw new Cache_Exception('Memcache PHP extention not loaded');
 		}
 
+		// Make sure that instant_death is in the default config
+		$config += array('instant_death' => TRUE);
+
 		parent::__construct($config);
 
 		// Setup Memcache


### PR DESCRIPTION
When a Memcache server dies or is unreachable, the `Cache_Memcache::_failed_request()` function causes a HTTP 500 error due to `$config['instant_death']` not being set.

This change fixes this, so if a Memcache server fails, Kohana will not cause a 500 error - it will simply mark the server as failed.
