### PR TITLE
Bugfix: Memcache module causes 500 error if a memcache server is not reachable

### DIFF
--- a/classes/Kohana/Cache/Memcache.php
+++ b/classes/Kohana/Cache/Memcache.php
@@ -287,9 +287,6 @@ class Kohana_Cache_Memcache extends Cache implements Cache_Arithmetic {
 	 */
 	public function _failed_request($hostname, $port)
 	{
-		if ( ! $this->_config['instant_death'])
-			return;
-
 		// Setup non-existent host
 		$host = FALSE;
 
@@ -301,6 +298,10 @@ class Kohana_Cache_Memcache extends Cache implements Cache_Arithmetic {
 			// We're looking at the failed server
 			if ($hostname == $server['host'] and $port == $server['port'])
 			{
+				// Make sure that we do not disable servers that have `instant_death` set to `FALSE`.
+				if ( ! $server['instant_death'])
+					continue;
+
 				// Server to disable, since it failed
 				$host = $server;
 				continue;


### PR DESCRIPTION
Stopping $config['instant_death'] from causing E500

When a Memcache server dies or is unreachable, the `Cache_Memcache::_failed_request()` function causes a HTTP 500 error due to `$config['instant_death']` not being set.

This change fixes this, so if a Memcache server fails, Kohana will not cause a 500 error - it will simply mark the server as failed.
