### PR TITLE
Catch RuntimeException

### DIFF
--- a/classes/Kohana/Cache/File.php
+++ b/classes/Kohana/Cache/File.php
@@ -177,6 +177,11 @@ class Kohana_Cache_File extends Cache implements Cache_GarbageCollect {
 			// Otherwise throw the exception
 			throw $e;
 		}
+		catch (RuntimeException $e)
+		{
+		    // Catch RuntimeException when cache file deleted between isFile and openFile
+		    return $default;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Catch RuntimeException when cache file deleted between isFile and openFile
can't find any code with getCode function as its set to zero so not checking code to catch any other issues the might throw RuntimeException

Signed-off-by: faraz faraz@adeogroup.co.uk
